### PR TITLE
fix: ensure that final completion message is sent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,8 @@ assistant: `;
                         };
                         if (data.completed) {
                             completed = true;
-                        } else {
-                            callback(data);
                         }
+                        callback(data);
                         break;
                     }
                     case "END": {


### PR DESCRIPTION
Hello - fantastic work on this project!

I noticed an issue when trying it out - the callback with `{ completed: true }` is never sent currently, since the logic is configured to not trigger the callback on the final completion (`\n\n<end>\n`) message.

This makes interacting with the model a bit tricky, since the calling code does not get notified when the response is finished.